### PR TITLE
no javascript if single payment pointer in array

### DIFF
--- a/lib/jekyll/web_monetization/tag.rb
+++ b/lib/jekyll/web_monetization/tag.rb
@@ -7,17 +7,26 @@ module Jekyll
       def render(context)
         site_payment_pointer = context.registers[:site].config["payment_pointer"]
         page_payment_pointer = context.registers[:page]["payment_pointer"] || site_payment_pointer
-        if page_payment_pointer.is_a?(Array) 
-          pointers_with_weights = array_to_object(page_payment_pointer)
-          return javascript(pointers_with_weights)
+
+        if page_payment_pointer.is_a?(Array)
+          if page_payment_pointer.length == 1
+            pointer_to_html(page_payment_pointer[0])
+          else
+            pointers_with_weights = array_to_object(page_payment_pointer)
+            return javascript(pointers_with_weights)
+          end
         elsif page_payment_pointer.is_a?(Hash)
           return javascript(page_payment_pointer)
         elsif page_payment_pointer.is_a?(String)
-          "<meta name='monetization' content='#{page_payment_pointer}'>"
+          pointer_to_html(page_payment_pointer)
         end
       end
 
       private
+
+      def pointer_to_html(pointer)
+        return "<meta name='monetization' content='#{pointer}'>"
+      end
 
       def array_to_object(pointers)
         pointers.reduce({}) { |acc, pointer| acc[pointer] = 1; acc }
@@ -38,7 +47,7 @@ module Jekyll
                   }
                 }
               }
-            
+
               window.addEventListener("load", function() {
                 const tag = document.createElement("meta");
                 tag.name = "monetization";
@@ -48,7 +57,7 @@ module Jekyll
             })();
           </script>
         JAVASCRIPT
-      end 
+      end
     end
   end
 end

--- a/spec/jekyll/web_monetization/tag_spec.rb
+++ b/spec/jekyll/web_monetization/tag_spec.rb
@@ -2,25 +2,25 @@
 
 RSpec.describe Jekyll::WebMonetization::Tag do
   let(:payment_pointer) { "$pay.money/to_me" }
-  
+
   let(:context)   { make_context(:page => page, :site => site) }
   let(:output)    { Liquid::Template.parse("{% web_monetization %}").render!(context, {}) }
 
   describe "with no payment pointer set for the site" do
     let(:site) { make_site }
-    
+
     describe "with a page" do
       describe "with no payment_pointer front matter" do
         let(:page) { make_page }
-  
+
         it "doesn't outputs a monetization meta tag" do
           expect(output).not_to include("monetization")
         end
       end
-  
+
       describe "with payment_pointer in the front matter" do
         let(:page) { make_page("payment_pointer" => "page_pointer") }
-  
+
         it "outputs a meta tag with the payment pointer" do
           expect(output).to include("<meta name='monetization' content='page_pointer'>")
         end
@@ -29,7 +29,7 @@ RSpec.describe Jekyll::WebMonetization::Tag do
       describe "with an array of payment_pointers in the front matter" do
         let(:payment_pointers) { ["$pay.money/to_me", "$example.payment/phil"] }
         let(:page) { make_page("payment_pointer" => payment_pointers) }
-  
+
         it "outputs a meta tag with the payment pointer" do
           expect(output).not_to include("<meta name='monetization' content='page_pointer'>")
         end
@@ -38,11 +38,20 @@ RSpec.describe Jekyll::WebMonetization::Tag do
           expect(output).to include('pickPointer({"$pay.money/to_me":1,"$example.payment/phil":1}, 2)')
         end
       end
-      
+
+      describe "with a singleton array of payment_pointers in the front matter" do
+        let(:payment_pointers) { ["page_pointer"] }
+        let(:page) { make_page("payment_pointer" => payment_pointers) }
+
+        it "outputs a meta tag with the payment pointer" do
+          expect(output).to include("<meta name='monetization' content='page_pointer'>")
+        end
+      end
+
       describe "with a hash of payment pointers in the front matter" do
         let(:payment_pointers) { { "$pay.money/to_me" => 10, "$example.payment/phil" => 20 } }
         let(:page) { make_page("payment_pointer" => payment_pointers) }
-  
+
         it "outputs a meta tag with the payment pointer" do
           expect(output).not_to include("<meta name='monetization' content='page_pointer'>")
         end
@@ -56,15 +65,15 @@ RSpec.describe Jekyll::WebMonetization::Tag do
     describe "with a post" do
       describe "with no payment_pointer front matter" do
         let(:page) { make_post }
-  
+
         it "doesn't outputs a monetization meta tag" do
           expect(output).not_to include("monetization")
         end
       end
-  
+
       describe "with payment_pointer in the front matter" do
         let(:page) { make_post("payment_pointer" => "post_pointer") }
-  
+
         it "outputs a meta tag with the payment pointer" do
           expect(output).to include("<meta name='monetization' content='post_pointer'>")
         end
@@ -74,7 +83,7 @@ RSpec.describe Jekyll::WebMonetization::Tag do
       describe "with an array of payment_pointers in the front matter" do
         let(:payment_pointers) { ["$pay.money/to_me", "$example.payment/phil"] }
         let(:page) { make_post("payment_pointer" => payment_pointers) }
-  
+
         it "outputs a meta tag with the payment pointer" do
           expect(output).not_to include("<meta name='monetization' content='page_pointer'>")
         end
@@ -87,7 +96,7 @@ RSpec.describe Jekyll::WebMonetization::Tag do
       describe "with a hash of payment pointers in the front matter" do
         let(:payment_pointers) { { "$pay.money/to_me" => 10, "$example.payment/phil" => 20 } }
         let(:page) { make_post("payment_pointer" => payment_pointers) }
-  
+
         it "outputs a meta tag with the payment pointer" do
           expect(output).not_to include("<meta name='monetization' content='page_pointer'>")
         end
@@ -95,13 +104,13 @@ RSpec.describe Jekyll::WebMonetization::Tag do
           expect(output).to include("<script>")
           expect(output).to include('pickPointer({"$pay.money/to_me":10,"$example.payment/phil":20}, 30)')
         end
-      end      
+      end
     end
   end
 
   describe "with a site-wide payment pointer" do
     let(:site) { make_site("payment_pointer" => payment_pointer) }
-  
+
     describe "with a page" do
       describe "with no payment_pointer front matter" do
         let(:page) { make_page }
@@ -119,7 +128,7 @@ RSpec.describe Jekyll::WebMonetization::Tag do
         end
       end
     end
-    
+
     describe "with a post" do
       describe "with no payment_pointer front matter" do
         let(:page) { make_post }


### PR DESCRIPTION
Previously when there was an array of payment pointer, it would always add a JavaScript function and select one according to the probabilistic revenue sharing function.

However, all of that can be skipped if there is only a single payment pointer in the array.

This modifies the function to add a check. If there is only 1 payment pointer in the function, just add it statically rather than the function to determine the only option available.

It also includes a test case to test the scenario described.

---

Some minor formatting changes are included which were performed by my editor.
I left them in since I plan to make a separate PR suggesting the use of EditorConfig anyway.